### PR TITLE
Fixed a bug causing incorrect calculation

### DIFF
--- a/app/src/main/java/com/akseltorgard/steganography/utils/BitmapUtils.java
+++ b/app/src/main/java/com/akseltorgard/steganography/utils/BitmapUtils.java
@@ -117,7 +117,7 @@ public class BitmapUtils {
         if (requiredLength < imageWidth) {
             return new int[] {requiredLength, 1};
         } else {
-            return new int[] {imageWidth, (int) Math.ceil(requiredLength / imageWidth) };
+            return new int[] {imageWidth, (int) Math.ceil(((double) requiredLength) / ((double) imageWidth)) };
         }
     }
 }


### PR DESCRIPTION
Minimum area was calculated incorrectly because of integer division. Corrected it by casting to double.